### PR TITLE
Update unaligned storage tests to pass via revive-dt-core

### DIFF
--- a/solidity/simple/storage/unaligned/array/assign.sol
+++ b/solidity/simple/storage/unaligned/array/assign.sol
@@ -2,13 +2,16 @@
 //!     "name": "main",
 //!     "inputs": [
 //!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "0x0000000000000000000000000000000000000000000000000000000004030201"
+//!             ]
+//!         },
+//!         {
 //!             "method": "main",
 //!             "calldata": [
 //!                 "42"
-//!             ],
-//!             "storage": { "Test.address": [
-//!                 "0x04030201"
-//!             ] }
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
@@ -20,6 +23,12 @@ contract Test {
     uint8[4] data;
 
     uint8 constant TEST = 42;
+
+    function setStorage(bytes32 newStorage) public {
+        assembly {
+            sstore(0, newStorage)
+        }
+    }
 
     function main(uint8 argument) public returns(uint8) {
         data[3] = argument;

--- a/solidity/simple/storage/unaligned/array/assign_nested.sol
+++ b/solidity/simple/storage/unaligned/array/assign_nested.sol
@@ -2,13 +2,16 @@
 //!     "name": "main",
 //!     "inputs": [
 //!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "0x00000000000000000000000000000000100f0e0d0c0b0a090807060504030201"
+//!             ]
+//!         },
+//!         {
 //!             "method": "main",
 //!             "calldata": [
 //!                 "42"
-//!             ],
-//!             "storage": { "Test.address": [
-//!                 "0x100f0e0d0c0b0a090807060504030201"
-//!             ] }
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
@@ -20,6 +23,12 @@ contract Test {
     uint8[4][4] data;
 
     uint8 constant TEST = 42;
+
+    function setStorage(bytes32 newStorage) public {
+        assembly {
+            sstore(0, newStorage)
+        }
+    }
 
     function main(uint8 argument) public returns(uint8) {
         data[3][3] = argument;

--- a/solidity/simple/storage/unaligned/array/mutating_one_element.sol
+++ b/solidity/simple/storage/unaligned/array/mutating_one_element.sol
@@ -2,12 +2,15 @@
 //!     "name": "complex",
 //!     "inputs": [
 //!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "1"
+//!             ]
+//!         },
+//!         {
 //!             "method": "complex",
 //!             "calldata": [
-//!             ],
-//!             "storage": { "Test.address": [
-//!                 "1"
-//!             ] }
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
@@ -23,6 +26,12 @@ pragma solidity >=0.4.16;
 
 contract Test {
     uint8[1] KEY = [1];
+
+    function setStorage(uint256 newStorage) public {
+        assembly {
+            sstore(0, newStorage)
+        }
+    }
 
     function complex() public view returns(uint8) {
         return KEY[0];

--- a/solidity/simple/storage/unaligned/array/product.sol
+++ b/solidity/simple/storage/unaligned/array/product.sol
@@ -2,13 +2,16 @@
 //!     "name": "main",
 //!     "inputs": [
 //!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "0x0000000000000000000000000000000000000000000000000005000a000f0014"
+//!             ]
+//!         },
+//!         {
 //!             "method": "main",
 //!             "calldata": [
 //!                 "42"
-//!             ],
-//!             "storage": { "Test.address": [
-//!                 "0x0005000a000f0014"
-//!             ] }
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
@@ -18,6 +21,12 @@
 
 contract Test {
     uint16[4] data;
+
+    function setStorage(bytes32 newStorage) public {
+        assembly {
+            sstore(0, newStorage)
+        }
+    }
 
     function main(uint16 argument) public returns(uint16) {
         uint16 product = 1;

--- a/solidity/simple/storage/unaligned/array/reassign.sol
+++ b/solidity/simple/storage/unaligned/array/reassign.sol
@@ -2,13 +2,16 @@
 //!     "name": "main",
 //!     "inputs": [
 //!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "0x0000000000000000000000000000000000000000000000000000000004030201"
+//!             ]
+//!         },
+//!         {
 //!             "method": "main",
 //!             "calldata": [
 //!                 "42"
-//!             ],
-//!             "storage": { "Test.address": [
-//!                 "0x04030201"
-//!             ] }
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
@@ -20,6 +23,12 @@ contract Test {
     uint8[4] data;
 
     uint8 constant TEST = 42;
+
+    function setStorage(bytes32 newStorage) public {
+        assembly {
+            sstore(0, newStorage)
+        }
+    }
 
     function main(uint8 argument) public returns(uint8) {
         data[3] += argument;

--- a/solidity/simple/storage/unaligned/array/reassign_nested.sol
+++ b/solidity/simple/storage/unaligned/array/reassign_nested.sol
@@ -2,16 +2,19 @@
 //!     "name": "main",
 //!     "inputs": [
 //!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "0x0000000000000000000000000000000000000000000000000000000004030201",
+//!                 "0x0000000000000000000000000000000000000000000000000000000008070605",
+//!                 "0x000000000000000000000000000000000000000000000000000000000c0b0a09",
+//!                 "0x00000000000000000000000000000000000000000000000000000000100f0e0d"
+//!             ]
+//!         },
+//!         {
 //!             "method": "main",
 //!             "calldata": [
 //!                 "42"
-//!             ],
-//!             "storage": { "Test.address": [
-//!                 "0x04030201",
-//!                 "0x08070605",
-//!                 "0x0c0b0a09",
-//!                 "0x100f0e0d"
-//!             ] }
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
@@ -23,6 +26,15 @@ contract Test {
     uint8[4][4] data;
 
     uint8 constant TEST = 42;
+
+    function setStorage(bytes32 a, bytes32 b, bytes32 c, bytes32 d) public {
+        assembly {
+            sstore(0, a)
+            sstore(1, b)
+            sstore(2, c)
+            sstore(3, d)
+        }
+    }
 
     function main(uint8 argument) public returns(uint8) {
         data[3][3] += argument;

--- a/solidity/simple/storage/unaligned/array/sum.sol
+++ b/solidity/simple/storage/unaligned/array/sum.sol
@@ -2,13 +2,16 @@
 //!     "name": "main",
 //!     "inputs": [
 //!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "0x00000000000000000000000000000000000000000000000000000000050a0f14"
+//!             ]
+//!         },
+//!         {
 //!             "method": "main",
 //!             "calldata": [
 //!                 "42"
-//!             ],
-//!             "storage": { "Test.address": [
-//!                 "0x050a0f14"
-//!             ] }
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
@@ -18,6 +21,12 @@
 
 contract Test {
     uint8[4] data;
+
+    function setStorage(bytes32 newStorage) public {
+        assembly {
+            sstore(0, newStorage)
+        }
+    }
 
     function main(uint8 argument) public returns(uint8) {
         uint8 sum = 0;

--- a/solidity/simple/storage/unaligned/complex_operator.sol
+++ b/solidity/simple/storage/unaligned/complex_operator.sol
@@ -2,13 +2,16 @@
 //!     "name": "main",
 //!     "inputs": [
 //!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "0x0000000000000000000000000000000000000000000000000000000000020503"
+//!             ]
+//!         },
+//!         {
 //!             "method": "main",
 //!             "calldata": [
 //!                 "16"
-//!             ],
-//!             "storage": { "Test.address": [
-//!                 "0x020503"
-//!             ] }
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
@@ -24,6 +27,12 @@ contract Test {
     uint8 field_1;
     uint8 field_2;
     uint8 field_3;
+
+    function setStorage(bytes32 newStorage) public {
+        assembly {
+            sstore(0, newStorage)
+        }
+    }
 
     function main(uint8 witness) public returns(uint8) {
         return 19 * 3 - 8 / field_1 + (witness / (field_2 - 3) + 5) * (8 / field_3 / 2);

--- a/solidity/simple/storage/unaligned/method_chain.sol
+++ b/solidity/simple/storage/unaligned/method_chain.sol
@@ -2,13 +2,24 @@
 //!     "name": "main",
 //!     "inputs": [
 //!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "0",
+//!                 "5"
+//!             ]
+//!         },
+//!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "1",
+//!                 "11"
+//!             ]
+//!         },
+//!         {
 //!             "method": "main",
 //!             "calldata": [
 //!                 "42"
-//!             ],
-//!             "storage": { "Test.address": [
-//!                 "5", "11"
-//!             ] }
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
@@ -23,6 +34,12 @@ pragma solidity >=0.4.16;
 contract Test {
     uint248 a;
     uint248 b;
+
+    function setStorage(uint256 idx, uint256 newStorage) public {
+        assembly {
+            sstore(idx, newStorage)
+        }
+    }
 
     function main(uint248 value) public returns(uint248) {
         return a + quadruple(triple(double(value))) + b;

--- a/solidity/simple/storage/unaligned/method_chain.sol
+++ b/solidity/simple/storage/unaligned/method_chain.sol
@@ -4,14 +4,7 @@
 //!         {
 //!             "method": "setStorage",
 //!             "calldata": [
-//!                 "0",
-//!                 "5"
-//!             ]
-//!         },
-//!         {
-//!             "method": "setStorage",
-//!             "calldata": [
-//!                 "1",
+//!                 "5",
 //!                 "11"
 //!             ]
 //!         },
@@ -35,9 +28,10 @@ contract Test {
     uint248 a;
     uint248 b;
 
-    function setStorage(uint256 idx, uint256 newStorage) public {
+    function setStorage(uint256 a, uint256 b) public {
         assembly {
-            sstore(idx, newStorage)
+            sstore(0, a)
+            sstore(1, b)
         }
     }
 

--- a/solidity/simple/storage/unaligned/mixed_data_origin.sol
+++ b/solidity/simple/storage/unaligned/mixed_data_origin.sol
@@ -2,13 +2,24 @@
 //!     "name": "main",
 //!     "inputs": [
 //!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "0",
+//!                 "5"
+//!             ]
+//!         },
+//!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "1",
+//!                 "7"
+//!             ]
+//!         },
+//!         {
 //!             "method": "main",
 //!             "calldata": [
 //!                 "42"
-//!             ],
-//!             "storage": { "Test.address": [
-//!                 "5", "7"
-//!             ] }
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
@@ -32,6 +43,12 @@ contract Test {
 
     uint248 a;
     uint248 b;
+
+    function setStorage(uint256 idx, uint256 newStorage) public {
+        assembly {
+            sstore(idx, newStorage)
+        }
+    }
 
     function main(uint248 value) public returns(uint248) {
         Data memory data = Data(10, 20);

--- a/solidity/simple/storage/unaligned/mixed_data_origin.sol
+++ b/solidity/simple/storage/unaligned/mixed_data_origin.sol
@@ -4,14 +4,7 @@
 //!         {
 //!             "method": "setStorage",
 //!             "calldata": [
-//!                 "0",
-//!                 "5"
-//!             ]
-//!         },
-//!         {
-//!             "method": "setStorage",
-//!             "calldata": [
-//!                 "1",
+//!                 "5",
 //!                 "7"
 //!             ]
 //!         },
@@ -44,9 +37,10 @@ contract Test {
     uint248 a;
     uint248 b;
 
-    function setStorage(uint256 idx, uint256 newStorage) public {
+    function setStorage(uint256 a, uint256 b) public {
         assembly {
-            sstore(idx, newStorage)
+            sstore(0, a)
+            sstore(1, b)
         }
     }
 

--- a/solidity/simple/storage/unaligned/mutating_conditional.sol
+++ b/solidity/simple/storage/unaligned/mutating_conditional.sol
@@ -2,15 +2,18 @@
 //!     "name": "false_false",
 //!     "inputs": [
 //!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "42"
+//!             ]
+//!         },
+//!         {
 //!             "method": "main",
 //!             "calldata": [
 //!                 "0",
 //!                 "0",
 //!                 "25"
-//!             ],
-//!             "storage": { "Test.address": [
-//!                 "42"
-//!             ] }
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
@@ -20,15 +23,18 @@
 //!     "name": "false_true",
 //!     "inputs": [
 //!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "42"
+//!             ]
+//!         },
+//!         {
 //!             "method": "main",
 //!             "calldata": [
 //!                 "0",
 //!                 "1",
 //!                 "25"
-//!             ],
-//!             "storage": { "Test.address": [
-//!                 "42"
-//!             ] }
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
@@ -38,15 +44,18 @@
 //!     "name": "true_false",
 //!     "inputs": [
 //!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "42"
+//!             ]
+//!         },
+//!         {
 //!             "method": "main",
 //!             "calldata": [
 //!                 "1",
 //!                 "0",
 //!                 "25"
-//!             ],
-//!             "storage": { "Test.address": [
-//!                 "42"
-//!             ] }
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
@@ -56,15 +65,18 @@
 //!     "name": "true_true",
 //!     "inputs": [
 //!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "42"
+//!             ]
+//!         },
+//!         {
 //!             "method": "main",
 //!             "calldata": [
 //!                 "1",
 //!                 "1",
 //!                 "25"
-//!             ],
-//!             "storage": { "Test.address": [
-//!                 "42"
-//!             ] }
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
@@ -78,6 +90,12 @@ pragma solidity >=0.4.16;
 
 contract Test {
     uint8 data;
+
+    function setStorage(uint256 newStorage) public {
+        assembly {
+            sstore(0, newStorage)
+        }
+    }
 
     function main(bool gate_1, bool gate_2, uint8 value) public returns(uint8) {
         if (gate_1) {

--- a/solidity/simple/storage/unaligned/simple_operator.sol
+++ b/solidity/simple/storage/unaligned/simple_operator.sol
@@ -2,13 +2,16 @@
 //!     "name": "main",
 //!     "inputs": [
 //!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "0x0000000000000000000000000000000000000000000000000000000000020503"
+//!             ]
+//!         },
+//!         {
 //!             "method": "main",
 //!             "calldata": [
 //!                 "12"
-//!             ],
-//!             "storage": { "Test.address": [
-//!                 "0x020503"
-//!             ] }
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
@@ -24,6 +27,12 @@ contract Test {
     uint8 field_1;
     uint8 field_2;
     uint8 field_3;
+
+    function setStorage(bytes32 newStorage) public {
+        assembly {
+            sstore(0, newStorage)
+        }
+    }
 
     function main(uint8 witness) public returns(uint8) {
         return witness + field_1 * field_2 * field_3;

--- a/solidity/simple/storage/unaligned/structure/assign.sol
+++ b/solidity/simple/storage/unaligned/structure/assign.sol
@@ -2,13 +2,16 @@
 //!     "name": "main",
 //!     "inputs": [
 //!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "0x0000000000000000000000000000000000000000000000000000000000656463"
+//!             ]
+//!         },
+//!         {
 //!             "method": "main",
 //!             "calldata": [
 //!                 "42"
-//!             ],
-//!             "storage": { "Test.address": [
-//!                 "0x656463"
-//!             ] }
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
@@ -26,6 +29,12 @@ contract Test {
     }
 
     Data data;
+
+    function setStorage(bytes32 newStorage) public {
+        assembly {
+            sstore(0, newStorage)
+        }
+    }
 
     function main(uint8 argument) public returns(uint8) {
         data.next = argument;

--- a/solidity/simple/storage/unaligned/structure/assign_nested.sol
+++ b/solidity/simple/storage/unaligned/structure/assign_nested.sol
@@ -2,13 +2,16 @@
 //!     "name": "main",
 //!     "inputs": [
 //!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "0x0000000000000000000000000000000000000000000000000000000000656463"
+//!             ]
+//!         },
+//!         {
 //!             "method": "main",
 //!             "calldata": [
 //!                 "42"
-//!             ],
-//!             "storage": { "Test.address": [
-//!                 "0x656463"
-//!             ] }
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
@@ -30,6 +33,12 @@ contract Test {
     }
 
     Data data;
+
+    function setStorage(bytes32 newStorage) public {
+        assembly {
+            sstore(0, newStorage)
+        }
+    }
 
     function main(uint8 argument) public returns(uint8) {
         data.inner.next = argument;

--- a/solidity/simple/storage/unaligned/structure/product.sol
+++ b/solidity/simple/storage/unaligned/structure/product.sol
@@ -2,13 +2,16 @@
 //!     "name": "main",
 //!     "inputs": [
 //!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "0x0000000000000000000000000000000000000000000000000005000a000f0014"
+//!             ]
+//!         },
+//!         {
 //!             "method": "main",
 //!             "calldata": [
 //!                 "42"
-//!             ],
-//!             "storage": { "Test.address": [
-//!                 "0x0005000a000f0014"
-//!             ] }
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
@@ -25,6 +28,12 @@ contract Test {
     }
 
     Data data;
+
+    function setStorage(bytes32 newStorage) public {
+        assembly {
+            sstore(0, newStorage)
+        }
+    }
 
     function main(uint16 argument) public returns(uint16) {
         uint16 product = 1;

--- a/solidity/simple/storage/unaligned/structure/reassign.sol
+++ b/solidity/simple/storage/unaligned/structure/reassign.sol
@@ -2,13 +2,16 @@
 //!     "name": "main",
 //!     "inputs": [
 //!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "0x0000000000000000000000000000000000000000000000000000000000656463"
+//!             ]
+//!         },
+//!         {
 //!             "method": "main",
 //!             "calldata": [
 //!                 "42"
-//!             ],
-//!             "storage": { "Test.address": [
-//!                 "0x656463"
-//!             ] }
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
@@ -26,6 +29,12 @@ contract Test {
     }
 
     Data data;
+
+    function setStorage(bytes32 newStorage) public {
+        assembly {
+            sstore(0, newStorage)
+        }
+    }
 
     function main(uint8 argument) public returns(uint8) {
         data.next += argument;

--- a/solidity/simple/storage/unaligned/structure/reassign_nested.sol
+++ b/solidity/simple/storage/unaligned/structure/reassign_nested.sol
@@ -2,13 +2,16 @@
 //!     "name": "main",
 //!     "inputs": [
 //!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "0x0000000000000000000000000000000000000000000000000000000000656463"
+//!             ]
+//!         },
+//!         {
 //!             "method": "main",
 //!             "calldata": [
 //!                 "42"
-//!             ],
-//!             "storage": { "Test.address": [
-//!                 "0x656463"
-//!             ] }
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
@@ -30,6 +33,12 @@ contract Test {
     }
 
     Data data;
+
+    function setStorage(bytes32 newStorage) public {
+        assembly {
+            sstore(0, newStorage)
+        }
+    }
 
     function main(uint8 argument) public returns(uint8) {
         data.inner.next += argument;

--- a/solidity/simple/storage/unaligned/structure/sum.sol
+++ b/solidity/simple/storage/unaligned/structure/sum.sol
@@ -2,13 +2,16 @@
 //!     "name": "main",
 //!     "inputs": [
 //!         {
+//!             "method": "setStorage",
+//!             "calldata": [
+//!                 "0x00000000000000000000000000000000000000000000000000000000050a0f14"
+//!             ]
+//!         },
+//!         {
 //!             "method": "main",
 //!             "calldata": [
 //!                 "42"
-//!             ],
-//!             "storage": { "Test.address": [
-//!                 "0x050a0f14"
-//!             ] }
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
@@ -27,6 +30,12 @@ contract Test {
     }
 
     Data data;
+
+    function setStorage(bytes32 newStorage) public {
+        assembly {
+            sstore(0, newStorage)
+        }
+    }
 
     function main(uint8 argument) public returns(uint8) {
         uint8 sum = 0;


### PR DESCRIPTION
# What / Why

This PR adjusts the unaligned storage tests to pass via `revive-dt-core`.

Storage values in solidity smart contracts live in slots. A slot is 32 bytes. By default, each storage value lives in its own slot, but where possible under certain conditions, storage values are packed into one slot.

Thus, each of the tests here is updated such that we have a `setStorage` method where we provide raw 32 byte values (either bytes32 or uint256 for convenience) for the slot or slots to set, and then the goal of each test itself in general is to assert that the actual storage values are as expected as a result of updating the slots.

I'd note that a bunch of tests don't do a good job of taking into account the _order_ in which storage values are packed into slots, ie they just multiply the storage values together, which means the packing could happen in any order and would still work. I'd be happy as part of a separate PR to improve tests to better check this, but felt it was out of scope here and we may decide to prioritise alignment with the source repo tests for easier merges.

# Testing

The command I run to test these from the `revive-differential-tests` repo is:

```
cargo r -p revive-dt-core -- --corpus ../corpus.json -f geth -r ../resolc --geth-start-timeout 5000
```

With the corpus.json at:

```json
{
    "name": "ML Solidity Complex",
    "path": "/path/to/era-compiler-tests/solidity/simple/storage/unaligned"
}
```